### PR TITLE
Make this project dead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+:warning: This project is unmaintained. If you're looking for a good example of Origami being used with React, have a look at the setup in [spark-lists](https://github.com/Financial-Times/spark-lists/tree/8eb8f61c84aaf9328ae7fad4e85c832b6bd63151/src/client/components/Origami#origami-react-components) :warning: 
+
 # Using Origami with React:
 
 ## To run

--- a/origami.json
+++ b/origami.json
@@ -4,7 +4,7 @@
 	"origamiVersion": 1,
 	"keywords": [],
 	"support": "https://github.com/Financial-Times/origami-react/issues",
-	"supportStatus": "active",
+	"supportStatus": "dead",
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/origami-support"


### PR DESCRIPTION
This stood as a good introduction to using Origami with React, and was something we could point to.

However these days I know some of us are more likely to point to @taktran's work on spark-lists

This repo, origami-react, hasn't seen an update in 2 years and React has seen a lot of changes since then. We're probably not going to maintain this, so shall we shelve it?

closes #12